### PR TITLE
docs/template: Issue Relationship運用に合わせて親子入力項目を整理

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -40,15 +40,6 @@ body:
       placeholder: 例) 作業時間を毎週30分削減できる
 
   - type: textarea
-    id: child_tasks
-    attributes:
-      label: Child Issue
-      description: 作成予定の Child Issue を `#123 タイトル` 形式で記載してください
-      placeholder: |
-        - [ ] #123 子Issueタイトル
-        - [ ] #124 子Issueタイトル
-
-  - type: textarea
     id: notes
     attributes:
       label: 補足

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -6,16 +6,6 @@ body:
     attributes:
       value: |
         このテンプレートは Child Issue 用です。Issue作成後に Parent Issue に紐付けてください。
-
-  - type: input
-    id: parent_task
-    attributes:
-      label: Parent Issue
-      description: 紐付け先の Parent Issue を `#123 タイトル` 形式で記載してください
-      placeholder: "例) #120 認証フロー改善"
-    validations:
-      required: true
-
   - type: textarea
     id: objective
     attributes:


### PR DESCRIPTION
## 背景
Issue Relationship運用へ統一するため、Issue本文で親子関係を入力させるテンプレート項目を廃止する。

## 変更内容
- `feature.yml` から `Child Tasks` 入力項目を削除
- `task.yml` から `Parent Task` 入力項目を削除
- 既存の Parent/Child Issue 説明文は維持

## 影響範囲
- `takatomo/.github` を既定テンプレートとして利用するリポジトリのIssue作成フォーム

## テスト結果
- `rg` で `child_tasks` / `parent_task` が除去されていることを確認
- Ruby YAMLロードで構文エラーがないことを確認

## 関連Issue
- Refs #4
- Closes #5
