### PR TITLE
docs/github: 関連Issue運用の明文化とREADME整合化

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,6 +6,8 @@ body:
     attributes:
       value: |
         不具合報告ありがとうございます。再現情報をできるだけ具体的に記入してください。
+        このIssueを単独で修正するPRでは `Closes #<Bug番号>` または `Fixes #<Bug番号>` を使用してください。
+        Parent Issue 配下で対応する場合は Parent Issue を `Refs #<Parent番号>` で参照してください。
 
   - type: input
     id: parent_issue

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,6 +7,7 @@ body:
       value: |
         機能提案ありがとうございます。背景と価値が分かる形で記載してください。
         このIssueは Parent Issue として扱います。実装は Child Issue を作成し、Parent Issue に紐付けてください。
+        実装PRでは Parent Issue を `Refs #<Parent番号>` で参照し、Child Issue を `Closes #<Child番号>` または `Fixes #<Child番号>` で記載してください。
 
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -6,6 +6,8 @@ body:
     attributes:
       value: |
         このテンプレートは Child Issue 用です。Issue作成後に Parent Issue に紐付けてください。
+        実装PRでは Child Issue を `Closes #<Child番号>` または `Fixes #<Child番号>` で記載してください。
+        Parent Issue は `Refs #<Parent番号>` で参照し、必要に応じてPR右ペインの Development でもリンクしてください。
   - type: textarea
     id: objective
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,5 +33,7 @@
 - 
 
 ## 関連Issue
-- Parent Issue: Refs #
-- Child Issue: Closes #
+- Parent Issue（必須）: Refs #<Parent番号>
+- Child Issue（必須・複数可）: Closes #<Child番号> または Fixes #<Child番号>
+- Child Issue 追加分: Closes #<Child番号>
+- Parent Issue を Linked issues に表示したい場合: PR右ペインの Development から手動リンクする

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 個人アカウント配下リポジトリ向けのデフォルトコミュニティヘルスファイル置き場です。
 
 - PR テンプレート: `.github/PULL_REQUEST_TEMPLATE.md`
-- Issue テンプレート: `.github/ISSUE_TEMPLATE/*.yml`
+- Issue テンプレート（Parent/Child運用）:
+  - `.github/ISSUE_TEMPLATE/feature.yml`（Parent Issue向け）
+  - `.github/ISSUE_TEMPLATE/task.yml`（Child Issue向け）
+  - `.github/ISSUE_TEMPLATE/bug.yml`（不具合報告。必要に応じてParent Issueへ紐付け）
+- Issue テンプレート設定: `.github/ISSUE_TEMPLATE/config.yml`（`blank_issues_enabled: true`）
 
 このリポジトリは、各リポジトリに同名ファイルがない場合の既定値として使われます。
 
@@ -11,4 +15,12 @@
 
 - 親となる課題は Parent Issue として起票する
 - 実装単位は Child Issue として起票し、Parent Issue に紐付ける
-- PR では `Parent Issue: Refs #...` と `Child Issue: Closes #...` を併記する
+- Featureテンプレートは Parent Issue 起票用、Taskテンプレートは Child Issue 起票用として使う
+- Bugテンプレートは単独修正でも Parent Issue 配下でも使える
+
+## PRの関連Issue記載ルール
+
+- Parent Issue は `Refs #<Parent番号>` で記載する（自動クローズはしない）
+- Child Issue は `Closes #<Child番号>` または `Fixes #<Child番号>` で記載する（自動クローズされる）
+- Child Issue が複数ある場合は `Closes #...` / `Fixes #...` を複数行で列挙する
+- Parent Issue を Linked issues に表示したい場合は、PR右ペインの `Development` から Parent Issue を手動リンクする


### PR DESCRIPTION
## 背景
READMEとテンプレート実体の記載に差分があり、関連Issue運用（Refs/Closes/Fixes/Development手動リンク）の解釈差が起きやすい状態だった。

## 変更内容
- READMEに `config.yml` の役割と Parent/Child 運用ルールを追記
- PRテンプレートの関連Issue欄を複数Child対応へ更新
- Feature/Task/BugのIssueテンプレートに関連Issue記載ルールを追記

## 影響範囲
- `.github` 配下のコミュニティヘルス文書とテンプレート
- 実装コード・CI動作への影響なし

## テスト結果
- Redチェック: 運用記載不足を確認（不足項目を検出）
- Greenチェック: `config.yml` / `Development` / `Closes/Fixes` 記載を確認
- `compat_gate.sh --profile shell-portability` PASS

## 関連Issue
- Parent Issue: Refs #7
- Child Issue: Closes #8
