### PR TITLE
fix: feature issue templateのYAML構文エラーを修正

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: 対象範囲
       description: 対象と非対象を明確にしてください
-      placeholder: 例) 対象: ダッシュボード画面 / 非対象: API仕様変更
+      placeholder: "例) 対象: ダッシュボード画面 / 非対象: API仕様変更"
     validations:
       required: true
 


### PR DESCRIPTION
## 背景
- `feature.yml` 読み込み時に YAML 構文エラー `mapping values are not allowed in this context` が発生していた

## 変更内容
- `.github/ISSUE_TEMPLATE/feature.yml` の `placeholder` 値をダブルクォートして YAML 構文を修正
- 文言自体は変更なし

## Multi-agent運用チェック
- main系直操作なし: yes
- preflight完了後にworker開始: yes

## 影響範囲
- [ ] UI
- [ ] API
- [ ] DB
- [ ] インフラ
- [x] ドキュメント
- [ ] その他

## テスト手順
1. `ruby -ryaml -e "YAML.load_file('.github/ISSUE_TEMPLATE/feature.yml')"`
2. `for f in .github/ISSUE_TEMPLATE/*.yml; do ruby -ryaml -e "YAML.load_file('$f')"; done`

## テスト結果
- [x] ローカルでテストを実施した
- [x] 既存テストが通る
- [ ] 必要なテストを追加または更新した
- 実行コマンド:
  - `ruby -ryaml -e "YAML.load_file('.github/ISSUE_TEMPLATE/feature.yml')"`
  - `for f in .github/ISSUE_TEMPLATE/*.yml; do ruby -ryaml -e "YAML.load_file('$f')"; done`
- 実行結果:
  - `.github/ISSUE_TEMPLATE/*.yml` の4ファイルすべて YAML パース成功
- 未実施項目がある場合の理由:
  - コード変更ではなくテンプレートの構文修正のため、追加テストコードは未実施

## セルフレビュー記録（1人運用）
- [x] 仕様逸脱なし（要件/設計との差分を確認）
- [x] 回帰リスク確認済み（影響範囲の洗い出し）
- [x] テスト不足なし（不足があれば理由を記載）
- [x] 境界値漏れなし（入力/分岐の端を確認）

## 関連Issue
- 該当なし（理由）: 単独のテンプレート修正
